### PR TITLE
Fix Wilson pion sink color-spin reconstruction

### DIFF
--- a/src/measurements/measure_Pion_correlator.jl
+++ b/src/measurements/measure_Pion_correlator.jl
@@ -304,7 +304,7 @@ function measure(
                                     @inbounds @simd for is2 = 1:Nspinor # Nspinor is the number of spinor index in 4d.
                                         β = spincolor(ic2, is2, NC)
                                         S[x, y, z, t, α0, β] +=
-                                            propagator[ic, x, y, z, t, is]
+                                            propagator[ic2, x, y, z, t, is2]
                                         #println( propagator[ic,x,y,z,t,is])
                                     end
                                 end

--- a/test/pion_correlator.jl
+++ b/test/pion_correlator.jl
@@ -1,0 +1,59 @@
+using Gaugefields
+using LatticeDiracOperators
+
+function direct_wilson_pion_correlator(U; κ=0.1)
+    source = Initialize_pseudofermion_fields(U[1], "Wilson")
+    solution = similar(source)
+    parameters = Dict(
+        "Dirac_operator" => "Wilson",
+        "κ" => κ,
+        "faster version" => true,
+        "boundarycondition" => [1, 1, 1, -1],
+        "eps_CG" => 1e-14,
+        "MaxCGstep" => 10_000,
+        "method_CG" => "bicg",
+        "verbose_level" => 0,
+    )
+    D = Dirac_operator(U, source, parameters)
+    correlator = zeros(Float64, U[1].NT)
+
+    for source_color in 1:3, source_spin in 1:4
+        clear_fermion!(source)
+        clear_fermion!(solution)
+        setindex_global!(
+            source,
+            1.0,
+            source_color,
+            1,
+            1,
+            1,
+            1,
+            source_spin,
+        )
+        solve_DinvX!(solution, D, source)
+        for t in 1:U[1].NT, z in 1:U[1].NZ, y in 1:U[1].NY,
+                x in 1:U[1].NX, sink_color in 1:3, sink_spin in 1:4
+            correlator[t] +=
+                abs2(solution[sink_color, x, y, z, t, sink_spin])
+        end
+    end
+
+    return correlator
+end
+
+@testset "Wilson pion correlator uses sink color-spin indices" begin
+    U = Initialize_4DGaugefields(3, 0, 2, 2, 2, 4; condition="cold")
+    expected = direct_wilson_pion_correlator(U)
+    measurement = Pion_correlator_measurement(
+        U;
+        fermiontype="Wilson",
+        κ=0.1,
+        BoundaryCondition=[1, 1, 1, -1],
+        eps_CG=1e-14,
+        MaxCGstep=10_000,
+        verbose_level=0,
+    )
+    observed = get_value(measure(measurement, U))
+
+    @test observed ≈ expected rtol=1e-12 atol=1e-12
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Test
     # Write your tests here.
 
     include("dicttest.jl")
+    include("pion_correlator.jl")
     include("gauge.jl")
 
 end


### PR DESCRIPTION
## What changed

- reconstruct each Wilson propagator matrix element with the sink loop indices `ic2` and `is2`
- add a regression test that independently evaluates
  `Cπ(t) = Σ |S_sink,source(x,t;0)|²` from all 12 point-source propagators
- run the regression test from the package test suite

## Root cause

The reconstruction loop scanned sink color and spin, but read the propagator with the fixed source indices `ic` and `is`. This copied one source component into every sink component instead of filling the sink color-spin matrix.

## Impact

Before the fix, the `2^3 × 4` cold-link regression produced
`[227.843656, 4.925547, 0, 4.925547]` instead of the direct contraction
`[18.986971, 1.369759, 0.548834, 1.369759]`.

## Validation

On Julia 1.11.6 over SSH:

- regression test on unmodified `9e04c37`: fails as expected
- the same test after the one-line fix: passes (`1/1`)
- complete `Pkg.test()` suite: passes (exit code `0`)
- PID, timestamps, exit codes, commit, and SHA-256 input manifests were recorded; the tested source and test hashes match commit `68d4baf`

GitHub Actions also passes all six combinations of Julia 1.11/latest on Linux, macOS, and Windows:
https://github.com/akio-tomiya/QCDMeasurements.jl/actions/runs/30550569155