### PR TITLE
Expose per-source pion solver diagnostics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RSCG = "4e41d8b6-e438-5f9c-8b78-0c738ca8d379"
 Wilsonloop = "f3c8d4fe-2f22-401d-8228-e6a01d7a1d02"
 
+[sources]
+LatticeDiracOperators = {url = "https://github.com/akio-tomiya/LatticeDiracOperators.jl.git", rev = "275ea6ef666adc6254abc71488015c0c83489f09"}
+
 [compat]
 Arpack = "0.5"
 Gaugefields = "0.4,0.5,0.6,0.7"

--- a/src/QCDMeasurements.jl
+++ b/src/QCDMeasurements.jl
@@ -3,6 +3,7 @@ using Wilsonloop
 using Gaugefields
 using LatticeDiracOperators
 using Arpack
+using LinearAlgebra
 import LatticeDiracOperators.Dirac_operators:
     clear_fermion!, AbstractFermionfields_4D, Z4_distribution_fermi!
 import Gaugefields.Temporalfields_module: Temporalfields,
@@ -14,7 +15,9 @@ include("measurements/AbstractMeasurement.jl")
 
 export Plaquette_measurement, measure, get_value, get_string
 export Polyakov_measurement
-export Pion_correlator_measurement
+export Pion_correlator_measurement,
+    PionSolverDiagnostic,
+    get_solver_diagnostics
 export Chiral_condensate_measurement
 export Energy_density_measurement
 export Correlation_measurement

--- a/src/measurements/measure_Pion_correlator.jl
+++ b/src/measurements/measure_Pion_correlator.jl
@@ -218,6 +218,7 @@ function Pion_correlator_measurement(
             U;
             filename=filename,
             cov_neural_net=cov_neural_net,
+            method_CG=params.method_CG,
             params_tuple...
             #=
             verbose_level = params.verbose_level,
@@ -237,6 +238,7 @@ function Pion_correlator_measurement(
             U;
             filename=filename,
             cov_neural_net=cov_neural_net,
+            method_CG=params.method_CG,
             params_tuple...
             #=
             verbose_level = params.verbose_level,
@@ -254,6 +256,7 @@ function Pion_correlator_measurement(
             U;
             filename=filename,
             cov_neural_net=cov_neural_net,
+            method_CG=params.method_CG,
             params_tuple...
             #=
             verbose_level = params.verbose_level,

--- a/src/measurements/measure_Pion_correlator.jl
+++ b/src/measurements/measure_Pion_correlator.jl
@@ -1,4 +1,16 @@
 
+struct PionSolverDiagnostic
+    source_number::Int
+    source_color::Int
+    source_spin::Int
+    method::Symbol
+    iterations::Int
+    recursive_residual_squared::Float64
+    target_residual_squared::Float64
+    maximum_iterations::Int
+    true_relative_residual::Float64
+end
+
 
 mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: AbstractMeasurement
     filename::Union{Nothing,String}
@@ -13,6 +25,7 @@ mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: Ab
     Nspinor::Int64
     S::Array{ComplexF64,Dim_2}
     cov_neural_net::TCov#Union{Nothing,CovNeuralnet}
+    solver_diagnostics::Vector{PionSolverDiagnostic}
 
     function Pion_correlator_measurement(
         U::Vector{T};
@@ -29,7 +42,8 @@ mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: Ab
         eps_CG=1e-14,
         MaxCGstep=5000,
         BoundaryCondition=nothing,
-        cov_neural_net=nothing
+        cov_neural_net=nothing,
+        method_CG=nothing,
     ) where {T}
         NC = U[1].NC
 
@@ -92,6 +106,17 @@ mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: Ab
         params["verbose_level"] = verbose_level
         params["MaxCGstep"] = MaxCGstep
         params["boundarycondition"] = boundarycondition
+        if method_CG !== nothing
+            method = String(method_CG)
+            method in ("bicg", "bicgstab", "preconditiond_bicgstab") ||
+                throw(
+                    ArgumentError(
+                        "method_CG must be bicg, bicgstab, or " *
+                        "preconditiond_bicgstab",
+                    ),
+                )
+            params["method_CG"] = method
+        end
 
         D = Dirac_operator(U, x, params)
         fermi_action = FermiAction(D, parameters_action)
@@ -138,10 +163,14 @@ mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: Ab
             Nspinor,#::Int64
             S,#::Array{ComplexF64,3}
             cov_neural_net,
+            PionSolverDiagnostic[],
         )
     end
 
 end
+
+get_solver_diagnostics(m::Pion_correlator_measurement) =
+    copy(m.solver_diagnostics)
 
 function Pion_correlator_measurement(
     U::Vector{T},
@@ -403,19 +432,18 @@ function calc_quark_propagators_point_source(
 ) where {NC,Dim}
     # D^{-1} for each spin x color element
     D = m.D(U)
-    stvec = String[]
-    propagators = map(
-        i -> calc_quark_propagators_point_source_each(m, U, D, i, stvec),
+    empty!(m.solver_diagnostics)
+    results = map(
+        i -> calc_quark_propagators_point_source_each(m, U, D, i),
         1:NC*m.Nspinor,
     )
-    st = ""
-    for i = 1:NC*m.Nspinor
-        st *= stvec[i] * "\n"
-    end
+    propagators = [result.propagator for result in results]
+    m.solver_diagnostics = [result.diagnostic for result in results]
+    st = join((result.measurestring for result in results), "\n") * "\n"
     return propagators, st
 end
 
-function calc_quark_propagators_point_source_each(m, U, D, i, stvec)
+function calc_quark_propagators_point_source_each(m, U, D, i)
     # calculate D^{-1} for a given source at the origin.
     # Nc*Ns (Ns: dim of spinor, Wilson=4, ks=1) elements has to be gathered.
     # staggered Pion correlator relies on https://itp.uni-frankfurt.de/~philipsen/theses/breitenfelder_ba.pdf (3.33)
@@ -463,7 +491,50 @@ function calc_quark_propagators_point_source_each(m, U, D, i, stvec)
     #println(p[ic,2,1,1,1,is])
     #Z4_distribution_fermi!(b)
     #error("dd")
-    @time solve_DinvX!(p, D, b)
+    solver_result = @time solve_DinvX!(p, D, b)
+    residual = similar(p)
+    clear_fermion!(residual)
+    mul!(residual, D, p)
+    add_fermion!(residual, -1, b)
+    source_norm_squared = real(b ⋅ b)
+    source_norm_squared > 0 ||
+        error("point source has zero norm for source $i")
+    true_relative_residual =
+        sqrt(real(residual ⋅ residual) / source_norm_squared)
+
+    method = hasproperty(solver_result, :method) ?
+             Symbol(getproperty(solver_result, :method)) :
+             Symbol(D.method_CG)
+    iterations = hasproperty(solver_result, :iterations) ?
+                 Int(getproperty(solver_result, :iterations)) :
+                 -1
+    recursive_residual_squared =
+        hasproperty(solver_result, :recursive_residual_squared) ?
+        Float64(
+            getproperty(
+                solver_result,
+                :recursive_residual_squared,
+            ),
+        ) : NaN
+    target_residual_squared =
+        hasproperty(solver_result, :target_residual_squared) ?
+        Float64(getproperty(solver_result, :target_residual_squared)) :
+        Float64(D.eps_CG)
+    maximum_iterations =
+        hasproperty(solver_result, :maximum_iterations) ?
+        Int(getproperty(solver_result, :maximum_iterations)) :
+        Int(D.MaxCGstep)
+    diagnostic = PionSolverDiagnostic(
+        i,
+        ic,
+        is,
+        method,
+        iterations,
+        recursive_residual_squared,
+        target_residual_squared,
+        maximum_iterations,
+        true_relative_residual,
+    )
     #error("dd")
     #println("norm p ",dot(p,p))
     st = "Hadron spectrum: Inversion $(i)/$(U[1].NC*m.Nspinor) is done"
@@ -471,6 +542,9 @@ function calc_quark_propagators_point_source_each(m, U, D, i, stvec)
     println_verbose_level1(U[1], st)
 
     flush(stdout)
-    push!(stvec, measurestring)
-    return deepcopy(p)
+    return (
+        propagator=deepcopy(p),
+        diagnostic,
+        measurestring,
+    )
 end

--- a/src/parameters/parameters.jl
+++ b/src/parameters/parameters.jl
@@ -84,6 +84,7 @@ Base.@kwdef mutable struct Pion_parameters <: Measurement_parameters
     fermiontype::String = "Wilson"
     eps::Float64 = 1e-19
     MaxCGstep::Int64 = 3000
+    method_CG::String = "bicg"
     smearing_for_fermion::String = "nothing"
     stout_numlayers::Int64 = 0#Union{Nothing,Int64} = nothing
     stout_ρ::Array{Float64,1} = zeros(1)#Vector{Float64}(undef, 1)#Union{Nothing,Array{Float64,1}} = nothing
@@ -436,6 +437,7 @@ function fermionparameter_params(params)
             r=fermionparameters.r,
             eps_CG=params.eps,
             MaxCGstep=params.MaxCGstep,
+            method_CG=params.method_CG,
         )
     elseif params.fermiontype == "Domainwall"
         #error("Domainwall fermion is not implemented in Pion measurement!")

--- a/src/parameters/parameters.jl
+++ b/src/parameters/parameters.jl
@@ -437,9 +437,6 @@ function fermionparameter_params(params)
             r=fermionparameters.r,
             eps_CG=params.eps,
             MaxCGstep=params.MaxCGstep,
-            method_CG=hasproperty(params, :method_CG) ?
-                      params.method_CG :
-                      "bicg",
         )
     elseif params.fermiontype == "Domainwall"
         #error("Domainwall fermion is not implemented in Pion measurement!")

--- a/src/parameters/parameters.jl
+++ b/src/parameters/parameters.jl
@@ -437,7 +437,9 @@ function fermionparameter_params(params)
             r=fermionparameters.r,
             eps_CG=params.eps,
             MaxCGstep=params.MaxCGstep,
-            method_CG=params.method_CG,
+            method_CG=hasproperty(params, :method_CG) ?
+                      params.method_CG :
+                      "bicg",
         )
     elseif params.fermiontype == "Domainwall"
         #error("Domainwall fermion is not implemented in Pion measurement!")

--- a/test/pion_solver_diagnostics.jl
+++ b/test/pion_solver_diagnostics.jl
@@ -1,0 +1,94 @@
+using Gaugefields
+
+U_solver_diagnostics = Initialize_Gaugefields(
+    3,
+    0,
+    2,
+    2,
+    2,
+    2;
+    condition="cold",
+)
+measurement_solver_diagnostics = Pion_correlator_measurement(
+    U_solver_diagnostics;
+    fermiontype="Wilson",
+    κ=0.10,
+    r=1.0,
+    eps_CG=1.0e-20,
+    MaxCGstep=10_000,
+    BoundaryCondition=[1, 1, 1, -1],
+    method_CG="bicgstab",
+    verbose_level=0,
+    printvalues=false,
+)
+output_solver_diagnostics =
+    get_value(measure(measurement_solver_diagnostics, U_solver_diagnostics))
+diagnostics = get_solver_diagnostics(measurement_solver_diagnostics)
+sorted_iterations =
+    sort([diagnostic.iterations for diagnostic in diagnostics])
+median_iterations =
+    (sorted_iterations[6] + sorted_iterations[7]) / 2
+
+@test length(output_solver_diagnostics) == 2
+@test length(diagnostics) == 12
+@test [diagnostic.source_number for diagnostic in diagnostics] == 1:12
+@test all(diagnostic -> diagnostic.method === :bicgstab, diagnostics)
+@test all(
+    diagnostic -> 0 < diagnostic.iterations <
+                  diagnostic.maximum_iterations,
+    diagnostics,
+)
+@test all(
+    diagnostic ->
+        diagnostic.recursive_residual_squared <
+        diagnostic.target_residual_squared,
+    diagnostics,
+)
+@test maximum(
+    diagnostic.true_relative_residual for diagnostic in diagnostics
+) < 1.0e-10
+
+@test_throws ArgumentError Pion_correlator_measurement(
+    U_solver_diagnostics;
+    fermiontype="Wilson",
+    method_CG="unsupported",
+)
+
+parameter_measurement_solver_diagnostics = Pion_correlator_measurement(
+    U_solver_diagnostics,
+    QCDMeasurements.Pion_parameters(
+        eps=1.0e-20,
+        MaxCGstep=10_000,
+        method_CG="bicgstab",
+        fermion_parameters=QCDMeasurements.Wilson_parameters(hop=0.10),
+        verbose_level=0,
+        printvalues=false,
+    ),
+)
+@test parameter_measurement_solver_diagnostics.D.method_CG == "bicgstab"
+
+failed_measurement_solver_diagnostics = Pion_correlator_measurement(
+    U_solver_diagnostics;
+    fermiontype="Wilson",
+    κ=0.10,
+    eps_CG=0.0,
+    MaxCGstep=0,
+    method_CG="bicgstab",
+    verbose_level=0,
+    printvalues=false,
+)
+@test_throws ErrorException measure(
+    failed_measurement_solver_diagnostics,
+    U_solver_diagnostics,
+)
+@test isempty(
+    get_solver_diagnostics(failed_measurement_solver_diagnostics),
+)
+
+@info "pion solver diagnostic metrics" minimum_iterations = minimum(
+    diagnostic.iterations for diagnostic in diagnostics
+) median_iterations maximum_iterations = maximum(
+    diagnostic.iterations for diagnostic in diagnostics
+) maximum_true_relative_residual = maximum(
+    diagnostic.true_relative_residual for diagnostic in diagnostics
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,7 @@ using QCDMeasurements
 using Test
 
 @testset "QCDMeasurements.jl" begin
-    # Write your tests here.
-
+    include("pion_solver_diagnostics.jl")
     include("dicttest.jl")
     include("pion_correlator.jl")
     include("gauge.jl")


### PR DESCRIPTION
## What

- retain structured LDO diagnostics for every pion point-source solve
- expose a `PionSolverDiagnostic` measurement record
- scope solver overrides to the pion measurement instead of mutating shared parameters
- preserve compatibility when measurement parameter dictionaries are shared
- add diagnostic and true-residual regression coverage
- pin the dependent LDO diagnostic stack in `Project.toml [sources]` for draft-PR CI

## Why / root cause

Pion measurement discarded solver outcomes and temporarily changed shared solver parameters, making convergence provenance unavailable and allowing measurement-specific settings to leak into other consumers.

The initial CI resolved the registered LDO release, which has no structured result, and therefore observed fallback `iterations=-1` and `recursive_residual=NaN`. The draft environment now resolves the exact dependency being reviewed.

## Impact

The correlator result is unchanged. Callers gain per-source convergence records, while shared parameter dictionaries remain stable.

## Stack

Builds on existing draft #35 and requires LatticeDiracOperators #83 head `275ea6ef666adc6254abc71488015c0c83489f09`. Replace the commit pin with release compatibility after the LDO changes are released.

## Checks

Validated through the final clean QCDMeasurements stack on `ubuntuamd` (CPU only, Julia/OpenBLAS threads = 1, GPU disabled):

- current PR head: `17d6f22103cf05c6793b644a80cb62140e7f7da0`
- final stack head: `ffab2ca72e394cbe8f7212fa6294a5c45f35ba81`
- full QCDMeasurements package tests: 23/23 passed
- exact LDO source pin verified in the generated Manifest
- GitHub Actions: all six Julia/OS lanes passed
- log root: `/home/akio/runs/juliaqcd_ci_fix_validation_20260806T0030JST_r4`