### PR TITLE
Stream pion correlator contraction

### DIFF
--- a/src/measurements/measure_Pion_correlator.jl
+++ b/src/measurements/measure_Pion_correlator.jl
@@ -23,7 +23,7 @@ mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: Ab
     _temporary_fermionfields::Vector{TF_vec}
     #Nr::Int64
     Nspinor::Int64
-    S::Array{ComplexF64,Dim_2}
+    S::Union{Nothing,Array{ComplexF64,Dim_2}}
     cov_neural_net::TCov#Union{Nothing,CovNeuralnet}
     solver_diagnostics::Vector{PionSolverDiagnostic}
 
@@ -98,8 +98,7 @@ mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: Ab
 
         Nspinor = ifelse(fermiontype == "Staggered", 1, 4)
 
-        _, _, NN... = size(U[1])
-        S = zeros(ComplexF64, NN..., Nspinor * NC, Nspinor * NC)
+        S = nothing
 
 
         params["eps_CG"] = eps_CG
@@ -279,14 +278,48 @@ end
     return ic - 1 + (is - 1) * NC + 1
 end
 
+function _accumulate_pion_correlator!(
+    Cpi,
+    propagator,
+    NC,
+    Nspinor,
+    NN,
+)
+    length(NN) == 4 || throw(ArgumentError("only four dimensions are supported"))
+    length(Cpi) == NN[4] ||
+        throw(DimensionMismatch("expected $(NN[4]) correlator times, got $(length(Cpi))"))
+    @inbounds for t = 1:NN[4]
+        contribution = 0.0
+        for z = 1:NN[3]
+            for y = 1:NN[2]
+                for x = 1:NN[1]
+                    for sink_color = 1:NC
+                        @simd for sink_spin = 1:Nspinor
+                            contribution += abs2(
+                                propagator[
+                                    sink_color,
+                                    x,
+                                    y,
+                                    z,
+                                    t,
+                                    sink_spin,
+                                ],
+                            )
+                        end
+                    end
+                end
+            end
+        end
+        Cpi[t] += contribution
+    end
+    return Cpi
+end
 
 function measure(
     m::M,
     U::Array{<:AbstractGaugefields{NC,Dim},1};
     additional_string="",
 ) where {M<:Pion_correlator_measurement,NC,Dim}
-    S = m.S
-    S .= 0
     measurestring = ""
     st = "Hadron spectrum started"
     measurestring *= st * "\n"
@@ -295,11 +328,11 @@ function measure(
     #D = m.D(U)
     # calculate quark propagators from a point source at he origin
     if m.cov_neural_net === nothing
-        propagators, st = calc_quark_propagators_point_source(m, U)
+        Cpi, st = calc_pion_correlator_point_source(m, U)
     else
         Uout, Uout_multi, _ = calc_smearedU(U, m.cov_neural_net)
         println("smeared U is used in Pion measurement")
-        propagators, st = calc_quark_propagators_point_source(m, Uout)
+        Cpi, st = calc_pion_correlator_point_source(m, Uout)
     end
     measurestring *= st * "\n"
     #=
@@ -319,78 +352,10 @@ function measure(
 
 
 
-    #ctr = 0 # a counter
-    for ic = 1:NC
-        for is = 1:Nspinor
-            icum = (ic - 1) * Nspinor + is
-
-            propagator = propagators[icum]
-            α0 = spincolor(ic, is, NC) # source(color-spinor) index
-            # reconstruction
-            if Dim == 4
-                @inbounds for t = 1:NN[4]
-                    for z = 1:NN[3]
-                        for y = 1:NN[2]
-                            for x = 1:NN[1]
-                                for ic2 = 1:NC
-                                    @inbounds @simd for is2 = 1:Nspinor # Nspinor is the number of spinor index in 4d.
-                                        β = spincolor(ic2, is2, NC)
-                                        S[x, y, z, t, α0, β] +=
-                                            propagator[ic2, x, y, z, t, is2]
-                                        #println( propagator[ic,x,y,z,t,is])
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end
-            else
-                error("Dim = $Dim is not supported")
-            end
-            # end for the substitution
-
-
-            #ctr+=1
-        end
-    end
-    #println(sum(S))
-    #error("prop")
-    # contruction end.
-    st = "Hadron spectrum: Reconstruction"
+    Dim == 4 || error("Dim = $Dim is not supported")
+    st = "Hadron spectrum: Contraction"
     measurestring *= st * "\n"
     println_verbose_level2(U[1], st)
-    #println("Hadron spectrum: Reconstruction")
-    Cpi = zeros(NN[end])
-    #Cpi = zeros( univ.NT )
-    # Construct Pion propagator 
-    if Dim == 4
-        @inbounds for t = 1:NN[4]
-            tmp = 0.0 + 0.0im
-            for z = 1:NN[3]
-                for y = 1:NN[2]
-                    for x = 1:NN[1]
-                        for ic = 1:NC
-                            for is = 1:Nspinor # Nspinor is the number of spinor index in 4d.
-                                α = spincolor(ic, is, NC)
-                                for ic2 = 1:NC
-                                    for is2 = 1:Nspinor # Nspinor is the number of spinor index in 4d.
-                                        β = spincolor(ic2, is2, NC)
-                                        tmp += S[x, y, z, t, α, β] * S[x, y, z, t, α, β]'#inner product.
-                                        # complex conjugate = g5 S g5.
-                                    end
-                                end
-                                # complex conjugate = g5 S g5.
-                            end
-                        end
-                    end
-                end
-            end
-            # staggered Pion correlator relies on https://itp.uni-frankfurt.de/~philipsen/theses/breitenfelder_ba.pdf (3.33)
-            # we adopt ignoreing the staggering factor. See detail above reference.
-            ksfact = 1.0 #ifelse( meas.fparam.Dirac_operator == "Staggered" , (-1)^(t-1) * 64, 1)
-            Cpi[t] = real(tmp) * ksfact
-        end
-    end
 
     #println(typeof(verbose),"\t",verbose)
     st = "Hadron spectrum end"
@@ -428,6 +393,44 @@ function measure(
 
 end
 
+function calc_pion_correlator_point_source(
+    m,
+    U::Array{<:AbstractGaugefields{NC,Dim},1},
+) where {NC,Dim}
+    D = m.D(U)
+    empty!(m.solver_diagnostics)
+    _, _, NN... = size(U[1])
+    Cpi = zeros(NN[end])
+    diagnostics = PionSolverDiagnostic[]
+    measurestrings = String[]
+    try
+        for i = 1:NC*m.Nspinor
+            result = calc_quark_propagators_point_source_each(
+                m,
+                U,
+                D,
+                i;
+                copy_propagator=false,
+            )
+            _accumulate_pion_correlator!(
+                Cpi,
+                result.propagator,
+                NC,
+                m.Nspinor,
+                NN,
+            )
+            push!(diagnostics, result.diagnostic)
+            push!(measurestrings, result.measurestring)
+        end
+    catch
+        empty!(m.solver_diagnostics)
+        rethrow()
+    end
+    m.solver_diagnostics = diagnostics
+    st = join(measurestrings, "\n") * "\n"
+    return Cpi, st
+end
+
 
 function calc_quark_propagators_point_source(
     m,
@@ -446,7 +449,13 @@ function calc_quark_propagators_point_source(
     return propagators, st
 end
 
-function calc_quark_propagators_point_source_each(m, U, D, i)
+function calc_quark_propagators_point_source_each(
+    m,
+    U,
+    D,
+    i;
+    copy_propagator=true,
+)
     # calculate D^{-1} for a given source at the origin.
     # Nc*Ns (Ns: dim of spinor, Wilson=4, ks=1) elements has to be gathered.
     # staggered Pion correlator relies on https://itp.uni-frankfurt.de/~philipsen/theses/breitenfelder_ba.pdf (3.33)
@@ -546,7 +555,7 @@ function calc_quark_propagators_point_source_each(m, U, D, i)
 
     flush(stdout)
     return (
-        propagator=deepcopy(p),
+        propagator=copy_propagator ? deepcopy(p) : p,
         diagnostic,
         measurestring,
     )

--- a/test/pion_solver_diagnostics.jl
+++ b/test/pion_solver_diagnostics.jl
@@ -30,6 +30,7 @@ median_iterations =
     (sorted_iterations[6] + sorted_iterations[7]) / 2
 
 @test length(output_solver_diagnostics) == 2
+@test measurement_solver_diagnostics.S === nothing
 @test length(diagnostics) == 12
 @test [diagnostic.source_number for diagnostic in diagnostics] == 1:12
 @test all(diagnostic -> diagnostic.method === :bicgstab, diagnostics)


### PR DESCRIPTION
## What

- accumulate the pion correlator immediately after each source solve
- avoid constructing and retaining a full lattice propagator
- keep the existing direct correlator oracle and assert that diagnostics do not retain the solved field

## Why / root cause

The measurement reconstructed the complete propagator even though the final observable only needs the running sum of squared propagator elements. This multiplied memory use by all source color-spin components and made large-volume measurements unnecessarily expensive.

## Impact

The contraction and public result are unchanged, but peak memory is reduced by streaming each solved source into the correlator.

## Stack

Depends on `agent/pion-solver-diagnostics`, including its exact LDO diagnostic dependency pin.

## Checks

Validated through the final clean QCDMeasurements stack on `ubuntuamd` (CPU only, Julia/OpenBLAS threads = 1, GPU disabled):

- current PR head: `608b31e5f450314deeaa89e12aaace51bb851cd7`
- final stack head: `ffab2ca72e394cbe8f7212fa6294a5c45f35ba81`
- full QCDMeasurements package tests: 23/23 passed
- exact LDO source pin verified in the generated Manifest
- log root: `/home/akio/runs/juliaqcd_ci_fix_validation_20260806T0030JST_r4`