### PR TITLE
Support even-odd pion solves with structured outcomes

### DIFF
--- a/src/measurements/measure_Pion_correlator.jl
+++ b/src/measurements/measure_Pion_correlator.jl
@@ -115,6 +115,12 @@ mutable struct Pion_correlator_measurement{Dim,TG,TD,TF,TF_vec,Dim_2,TCov} <: Ab
                     ),
                 )
             params["method_CG"] = method
+            if fermiontype == "Wilson" &&
+               method == "preconditiond_bicgstab"
+                # LatticeDiracOperators currently defines its even-odd
+                # wrapper only for the standard Wilson operator.
+                params["faster version"] = false
+            end
         end
 
         D = Dirac_operator(U, x, params)

--- a/src/measurements/measure_Pion_correlator.jl
+++ b/src/measurements/measure_Pion_correlator.jl
@@ -5,6 +5,8 @@ struct PionSolverDiagnostic
     source_spin::Int
     method::Symbol
     iterations::Int
+    restart_count::Int
+    convergence_branch::Symbol
     recursive_residual_squared::Float64
     target_residual_squared::Float64
     maximum_iterations::Int
@@ -520,34 +522,53 @@ function calc_quark_propagators_point_source_each(
     true_relative_residual =
         sqrt(real(residual ⋅ residual) / source_norm_squared)
 
-    method = hasproperty(solver_result, :method) ?
-             Symbol(getproperty(solver_result, :method)) :
-             Symbol(D.method_CG)
-    iterations = hasproperty(solver_result, :iterations) ?
-                 Int(getproperty(solver_result, :iterations)) :
-                 -1
+    required_diagnostic_properties = (
+        :method,
+        :iterations,
+        :restart_count,
+        :convergence_branch,
+        :recursive_residual_squared,
+        :target_residual_squared,
+        :maximum_iterations,
+    )
+    for property in required_diagnostic_properties
+        hasproperty(solver_result, property) || error(
+            "solver $(D.method_CG) did not report $property for source $i",
+        )
+    end
+
+    method = Symbol(getproperty(solver_result, :method))
+    iterations = Int(getproperty(solver_result, :iterations))
+    restart_count = Int(getproperty(solver_result, :restart_count))
+    convergence_branch =
+        Symbol(getproperty(solver_result, :convergence_branch))
     recursive_residual_squared =
-        hasproperty(solver_result, :recursive_residual_squared) ?
-        Float64(
-            getproperty(
-                solver_result,
-                :recursive_residual_squared,
-            ),
-        ) : NaN
+        Float64(getproperty(solver_result, :recursive_residual_squared))
     target_residual_squared =
-        hasproperty(solver_result, :target_residual_squared) ?
-        Float64(getproperty(solver_result, :target_residual_squared)) :
-        Float64(D.eps_CG)
+        Float64(getproperty(solver_result, :target_residual_squared))
     maximum_iterations =
-        hasproperty(solver_result, :maximum_iterations) ?
-        Int(getproperty(solver_result, :maximum_iterations)) :
-        Int(D.MaxCGstep)
+        Int(getproperty(solver_result, :maximum_iterations))
+
+    iterations >= 0 || error(
+        "solver $(D.method_CG) reported invalid iteration count $iterations for source $i",
+    )
+    restart_count >= 0 || error(
+        "solver $(D.method_CG) reported invalid restart count $restart_count for source $i",
+    )
+    convergence_branch !== :unknown || error(
+        "solver $(D.method_CG) did not report its convergence branch for source $i",
+    )
+    isfinite(recursive_residual_squared) || error(
+        "solver $(D.method_CG) reported a non-finite recursive residual for source $i",
+    )
     diagnostic = PionSolverDiagnostic(
         i,
         ic,
         is,
         method,
         iterations,
+        restart_count,
+        convergence_branch,
         recursive_residual_squared,
         target_residual_squared,
         maximum_iterations,

--- a/test/pion_solver_diagnostics.jl
+++ b/test/pion_solver_diagnostics.jl
@@ -71,6 +71,98 @@ preconditioned_measurement_solver_diagnostics =
     string(typeof(preconditioned_measurement_solver_diagnostics.D)),
 )
 
+U_hot_solver_crosscheck = Initialize_Gaugefields(
+    3,
+    0,
+    2,
+    2,
+    2,
+    2;
+    condition="hot",
+    randomnumber="Reproducible",
+)
+normal_hot_measurement = Pion_correlator_measurement(
+    U_hot_solver_crosscheck;
+    fermiontype="Wilson",
+    κ=0.10,
+    r=1.0,
+    eps_CG=1.0e-20,
+    MaxCGstep=10_000,
+    BoundaryCondition=[1, 1, 1, -1],
+    method_CG="bicgstab",
+    verbose_level=0,
+    printvalues=false,
+)
+evenodd_hot_measurement = Pion_correlator_measurement(
+    U_hot_solver_crosscheck;
+    fermiontype="Wilson",
+    κ=0.10,
+    r=1.0,
+    eps_CG=1.0e-20,
+    MaxCGstep=10_000,
+    BoundaryCondition=[1, 1, 1, -1],
+    method_CG="preconditiond_bicgstab",
+    verbose_level=0,
+    printvalues=false,
+)
+normal_hot_correlator =
+    get_value(measure(normal_hot_measurement, U_hot_solver_crosscheck))
+evenodd_hot_correlator =
+    get_value(measure(evenodd_hot_measurement, U_hot_solver_crosscheck))
+normal_hot_diagnostics = get_solver_diagnostics(normal_hot_measurement)
+evenodd_hot_diagnostics = get_solver_diagnostics(evenodd_hot_measurement)
+
+@test length(normal_hot_diagnostics) == 12
+@test length(evenodd_hot_diagnostics) == 12
+@test all(
+    diagnostic ->
+        diagnostic.method === :bicgstab &&
+        0 < diagnostic.iterations < diagnostic.maximum_iterations &&
+        isfinite(diagnostic.recursive_residual_squared) &&
+        diagnostic.recursive_residual_squared <
+        diagnostic.target_residual_squared &&
+        isfinite(diagnostic.true_relative_residual) &&
+        diagnostic.true_relative_residual < 1.0e-10,
+    normal_hot_diagnostics,
+)
+@test all(
+    diagnostic ->
+        diagnostic.method === :preconditiond_bicgstab &&
+        0 < diagnostic.iterations < diagnostic.maximum_iterations &&
+        isfinite(diagnostic.recursive_residual_squared) &&
+        diagnostic.recursive_residual_squared <
+        diagnostic.target_residual_squared &&
+        isfinite(diagnostic.true_relative_residual) &&
+        diagnostic.true_relative_residual < 1.0e-10,
+    evenodd_hot_diagnostics,
+)
+hot_correlator_relative_difference = sqrt(
+    sum(abs2, evenodd_hot_correlator - normal_hot_correlator) /
+    sum(abs2, normal_hot_correlator),
+)
+@test isfinite(hot_correlator_relative_difference)
+@test hot_correlator_relative_difference < 1.0e-8
+
+normal_hot_iterations =
+    [diagnostic.iterations for diagnostic in normal_hot_diagnostics]
+evenodd_hot_iterations =
+    [diagnostic.iterations for diagnostic in evenodd_hot_diagnostics]
+normal_hot_maximum_true_relative_residual =
+    maximum(
+        diagnostic.true_relative_residual
+        for diagnostic in normal_hot_diagnostics
+    )
+evenodd_hot_maximum_true_relative_residual =
+    maximum(
+        diagnostic.true_relative_residual
+        for diagnostic in evenodd_hot_diagnostics
+    )
+@info "hot pion solver cross-check" hot_correlator_relative_difference normal_minimum_iterations =
+    minimum(normal_hot_iterations) normal_maximum_iterations =
+    maximum(normal_hot_iterations) evenodd_minimum_iterations =
+    minimum(evenodd_hot_iterations) evenodd_maximum_iterations =
+    maximum(evenodd_hot_iterations) normal_hot_maximum_true_relative_residual evenodd_hot_maximum_true_relative_residual
+
 parameter_measurement_solver_diagnostics = Pion_correlator_measurement(
     U_solver_diagnostics,
     QCDMeasurements.Pion_parameters(

--- a/test/pion_solver_diagnostics.jl
+++ b/test/pion_solver_diagnostics.jl
@@ -34,6 +34,12 @@ median_iterations =
 @test length(diagnostics) == 12
 @test [diagnostic.source_number for diagnostic in diagnostics] == 1:12
 @test all(diagnostic -> diagnostic.method === :bicgstab, diagnostics)
+@test all(diagnostic -> diagnostic.restart_count >= 0, diagnostics)
+@test all(
+    diagnostic -> diagnostic.convergence_branch in
+                  (:intermediate_residual, :updated_residual),
+    diagnostics,
+)
 @test all(
     diagnostic -> 0 < diagnostic.iterations <
                   diagnostic.maximum_iterations,
@@ -118,6 +124,9 @@ evenodd_hot_diagnostics = get_solver_diagnostics(evenodd_hot_measurement)
     diagnostic ->
         diagnostic.method === :bicgstab &&
         0 < diagnostic.iterations < diagnostic.maximum_iterations &&
+        diagnostic.restart_count >= 0 &&
+        (diagnostic.convergence_branch in
+         (:intermediate_residual, :updated_residual)) &&
         isfinite(diagnostic.recursive_residual_squared) &&
         diagnostic.recursive_residual_squared <
         diagnostic.target_residual_squared &&
@@ -129,6 +138,9 @@ evenodd_hot_diagnostics = get_solver_diagnostics(evenodd_hot_measurement)
     diagnostic ->
         diagnostic.method === :preconditiond_bicgstab &&
         0 < diagnostic.iterations < diagnostic.maximum_iterations &&
+        diagnostic.restart_count >= 0 &&
+        (diagnostic.convergence_branch in
+         (:intermediate_residual, :updated_residual)) &&
         isfinite(diagnostic.recursive_residual_squared) &&
         diagnostic.recursive_residual_squared <
         diagnostic.target_residual_squared &&

--- a/test/pion_solver_diagnostics.jl
+++ b/test/pion_solver_diagnostics.jl
@@ -55,6 +55,22 @@ median_iterations =
     method_CG="unsupported",
 )
 
+preconditioned_measurement_solver_diagnostics =
+    Pion_correlator_measurement(
+        U_solver_diagnostics;
+        fermiontype="Wilson",
+        κ=0.10,
+        method_CG="preconditiond_bicgstab",
+        verbose_level=0,
+        printvalues=false,
+    )
+@test preconditioned_measurement_solver_diagnostics.D.method_CG ==
+      "preconditiond_bicgstab"
+@test !occursin(
+    "faster",
+    string(typeof(preconditioned_measurement_solver_diagnostics.D)),
+)
+
 parameter_measurement_solver_diagnostics = Pion_correlator_measurement(
     U_solver_diagnostics,
     QCDMeasurements.Pion_parameters(


### PR DESCRIPTION
## What

- select the Wilson operator form compatible with even-odd pion solves
- require structured solver outcomes instead of fabricating sentinel diagnostics
- propagate restart count and convergence branch to pion diagnostics
- compare hot-field even-odd and unpreconditioned correlators
- cover all supported solver selections

## Why / root cause

The pion path assumed one Wilson operator shape and accepted missing diagnostic fields by substituting `-1`/`NaN`. That masked unsupported or incomplete solver outcomes and prevented the even-odd route from being validated end to end.

## Impact

Even-odd pion measurements now use a compatible operator and fail clearly if a solver does not return the required structured result. Valid solves expose the same diagnostic schema across methods.

## Stack

Depends on `agent/pion-streaming-contraction` and, transitively, the preceding diagnostic PR, LDO #83, and existing draft #35.

## Checks

On `ubuntuamd` (CPU only, Julia/OpenBLAS threads = 1, GPU disabled):

- targeted hot-field even-odd agreement and diagnostic tests: passed
- full QCDMeasurements package tests: 23/23 passed
- exact tested head: `ffab2ca72e394cbe8f7212fa6294a5c45f35ba81`
- exact LDO source pin: `275ea6ef666adc6254abc71488015c0c83489f09`
- log root: `/home/akio/runs/juliaqcd_ci_fix_validation_20260806T0030JST_r4`